### PR TITLE
chore: use CFn stack name for SNS topic name

### DIFF
--- a/template.yaml
+++ b/template.yaml
@@ -86,7 +86,7 @@ Resources:
   CodePipelineApprovalActionTopic:
     Type: 'AWS::SNS::Topic'
     Properties:
-      TopicName: 'CodePipelineApprovalAction'
+      TopicName: !Ref AWS::StackName
 
 Outputs:
   ServiceEndpoint:


### PR DESCRIPTION
## Description

Use CFn stack name for SNS topic name.

## Motivation

Deploy another stack in same account, SNS topic name conflicts occurred.