### PR TITLE
Fix ruby version from 2.5 to 2.7

### DIFF
--- a/template.yaml
+++ b/template.yaml
@@ -34,7 +34,7 @@ Resources:
     Properties:
       CodeUri: ./target/app.zip
       Handler: app/notify_approval_action.handler
-      Runtime: ruby2.5
+      Runtime: ruby2.7
       Description: Subscribe CodePipeline Approval action and notify.
       MemorySize: 128
       Timeout: 3
@@ -61,7 +61,7 @@ Resources:
     Properties:
       CodeUri: ./target/app.zip
       Handler: app/approval_result_callback.handler
-      Runtime: ruby2.5
+      Runtime: ruby2.7
       Description: Performe CodePipeline Approval action.
       MemorySize: 128
       Timeout: 3


### PR DESCRIPTION
It seems that the ruby version used by the template needs to be updated.

![스크린샷 2023-02-28 오후 11 30 21](https://user-images.githubusercontent.com/26675063/221883845-9d788e4f-41aa-49f3-8381-1f447348293e.png)
